### PR TITLE
Extend benchmarks to 15s runs with 10s window

### DIFF
--- a/cpuWorker.js
+++ b/cpuWorker.js
@@ -6,7 +6,13 @@ self.onmessage = (e) => {
   const res = cpuKernel(iterations >>> 0);
   const t1 = performance.now();
   // Post minimal info to avoid overhead
-  self.postMessage({ iterations, durationMs: t1 - t0, checksum: res >>> 0 });
+  self.postMessage({
+    iterations,
+    durationMs: t1 - t0,
+    startTime: t0,
+    endTime: t1,
+    checksum: res >>> 0,
+  });
 };
 
 // A mixed integer bitwise kernel with good JIT stability


### PR DESCRIPTION
## Summary
- add worker timing metadata so benchmarks know chunk boundaries
- run CPU single and multi worker loops for 15s and score the trailing 10s window
- extend the GPU paths to loop for 15s and report scores from the last 10s of work

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d35cc839948333ae1dda1cb8621c46