### PR TITLE
Avoid blocking UI during WebGL GPU benchmark

### DIFF
--- a/main.js
+++ b/main.js
@@ -444,7 +444,9 @@ async function runGpu(totalMs = 15_000, windowMs = 10_000) {
     let firstStart = null;
     const pixels = canvas.width * canvas.height;
     const workPerFrame = pixels * 2000;
+    const nextFrame = () => new Promise(requestAnimationFrame);
     while (true) {
+      await nextFrame();
       const start = performance.now();
       gl.uniform1f(tLoc, records.length / 60);
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);


### PR DESCRIPTION
## Summary
- yield control to the browser event loop between WebGL benchmark frames so the page stays responsive while the GPU test runs

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68d365283d448333b0ad42f719127028