### PR TITLE
Increase GPU benchmark load

### DIFF
--- a/main.js
+++ b/main.js
@@ -412,7 +412,8 @@ async function runGpu(totalMs = 15_000, windowMs = 10_000) {
       lim.maxComputeWorkgroupSizeX ?? 256,
       lim.maxComputeInvocationsPerWorkgroup ?? 256
     ));
-    const groups = 2048;
+    const maxGroups = Math.max(1, Math.min(8192, lim.maxComputeWorkgroupsPerDimension ?? 65535));
+    const groups = maxGroups;
     const invocations = workgroupSize * groups;
 
     let shader = /* wgsl */`


### PR DESCRIPTION
## Summary
- scale the WebGPU compute benchmark to use the maximum supported X-dimension workgroups (capped at 8192)
- increase the number of concurrent invocations per dispatch to drive higher GPU utilization

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68d410b72858833382323967faff8183